### PR TITLE
fix(timestamp-format): Update readme and return string type from getTimestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Qeepsake React Native File Utils
 
-## NOTE: Currently a work in progress. Not production ready.
-
-Extracts information about media files including MIME type, duration (vide), dimensions, or timestamp of a media file with React Native on iOS and Android (uses Java and Obj-C, not Node).
+Extracts information from image and video files including MIME type, duration (video), dimensions, and timestamp. The library work on iOS and Android and uses Java and Obj-C native library (not Node).
 
 ## Installation
 
@@ -49,7 +47,7 @@ Gets the timestamp (js Date) of the media file at the passed Uri.
 ```js
 import { getTimestamp } from '@qeepsake/react-native-file-utils';
 
-const timestamp = await getTimestamp('file://<media-path>');
+const timestamp = await getTimestamp('file://<media-path>', 'video');
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ const durationMs = await getDuration('file://<media-path>');
 
 ### Get the media file dimensions in pixels
 
-Gets the horizontal (x) and vertical (y) pixels of the media item, either image or video. The returned media dimensions includes both the horizontal (x) length in pixels and vertical (y) length in pixels.
+Gets the horizontal (x) and vertical (y) pixels of the media item, either image or video. The returned media dimensions includes an object with both the horizontal (x) length in pixels and vertical (y) length in pixels.
 
 ```js
 import { getDimensions } from '@qeepsake/react-native-file-utils';
@@ -42,7 +42,9 @@ const mimeType = await getMimeType('file://<media-path>');
 
 ### Get the timestamp of a media item file
 
-Gets the timestamp (js Date) of the media file at the passed Uri.
+Gets the string timestamp of the media file from the passed Uri. The timestamp is usually a date retrieved
+from either the Exif date if the original datetime of the media is available or by the creation/last modified
+timestamp from the file itself.
 
 ```js
 import { getTimestamp } from '@qeepsake/react-native-file-utils';

--- a/android/src/main/java/com/reactnativefileutils/FileUtilsModule.java
+++ b/android/src/main/java/com/reactnativefileutils/FileUtilsModule.java
@@ -121,7 +121,7 @@ public class FileUtilsModule extends ReactContextBaseJavaModule {
    *
    * @param uri       - The video or image file path to get the timestamp of.
    * @param mediaType - Either 'video' or 'image' so the method knows how to process the media file.
-   * @returns ISO datetime of the image or video file from the file's Exif data.
+   * @returns String ISO datetime of the image or video file from the file's Exif data.
    */
   @ReactMethod
   public void getTimestamp(String uri, String mediaType, Promise promise) {

--- a/ios/FileUtils.m
+++ b/ios/FileUtils.m
@@ -83,7 +83,7 @@ RCT_EXPORT_METHOD(
  * image or video file. Note: Either asset-libarary path or full file path may be passed in.
  * @param path - The video or image file path to get the timestamp of.
  * @param type - Either 'video' or 'image' so the method knows how to process the media file.
- * @returns The datetime of the image or video file from the file's Exif data.
+ * @returns The string timestamp of the image or video file.
  */
 RCT_EXPORT_METHOD(
                   getTimestamp:(NSString *)path

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -59,7 +59,7 @@ export function getMimeType(uri: string): Promise<string> {
 }
 
 /**
- * Gets the date time of the media file at the passed Uri. The date time is retrieved
+ * Gets the string date time of the media file at the passed Uri. The date time is retrieved
  * from the Exif data if an image is passed and creation date if a video is passed.
  * @param uri The full file uri or the asset-library path for the media item.
  * @param fileType Either image or video.
@@ -68,6 +68,6 @@ export function getMimeType(uri: string): Promise<string> {
 export function getTimestamp(
   uri: string,
   mediaType: 'image' | 'video'
-): Promise<Date> {
+): Promise<string> {
   return FileUtils.getTimestamp(uri, mediaType);
 }


### PR DESCRIPTION
Attempted returning JS Date always from getTimestamp but saw that Exif metadata could possibly come in a bunch of different formats, and is natively pulled out as strings from iOS and Android. So after seeing that, thought it might be better to keep this library closer to the metal and return the string from native. Any thoughts on this @lukebrandonfarrell ?